### PR TITLE
Update babel-maven-plugin to version 1.2, configure encoding charset to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <minify-maven-plugin.version>1.7.6</minify-maven-plugin.version>
         <maven-replacer-plugin.version>1.4.1</maven-replacer-plugin.version>
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
-        <babel-maven-plugin.version>1.1</babel-maven-plugin.version>
+        <babel-maven-plugin.version>1.2</babel-maven-plugin.version>
         <!-- dependencies -->
         <babel.version>6.26.0</babel.version>
         <react.version>16.7.0</react.version>
@@ -229,6 +229,7 @@
                                     </jsSourceIncludes>
                                     <prefix>trans-</prefix>
                                     <presets>react,es2015</presets>
+                                    <encoding>UTF-8</encoding>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Fix the build error while selected charset by babel-maven-plugin is not UTF-8:
`Failed on Babel transpile execution. javax.script.ScriptException: SyntaxError: empty range in char class in <eval> at line number 4.`